### PR TITLE
Dependencies: Remove unnecessary dependency on Angular 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,10 @@
   "homepage": "https://github.com/btroncone/ngrx-store-logger#readme",
   "peerDependencies": {
     "rxjs": "^5.0.0-beta.6",
-    "@angular/core": "2.0.0-rc.1",
-    "@ngrx/store": "^2.0.0"
+    "@ngrx/store": "^2.0.1"
   },
   "devDependencies": {
-    "@angular/core": "2.0.0-rc.1",
-    "@ngrx/core": "^1.0.0",
+    "@ngrx/core": "^1.0.1",
     "es6-promise": "^3.0.2",
     "es6-shim": "^0.33.13",
     "reflect-metadata": "0.1.2",
@@ -41,8 +39,7 @@
     "tslint": "^3.4.0",
     "typescript": "^1.7.3",
     "typings": "^0.6.6",
-    "zone.js": "0.5.15",
-    "@ngrx/store": "^1.5.0",
+    "@ngrx/store": "^2.0.1",
     "rxjs": "^5.0.0-beta.6"
   },
   "typings": "./dist/index.d.ts"


### PR DESCRIPTION
ngrx no longer depends on Angular 2, so it would be good to reflect that in this project.

I am successfully using the ngrx and this logger in my Angular 1 app with the attached changes in place.
