### PR TITLE
Allow universal rendering

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ const printBuffer = options => logBuffer => {
 
 export const storeLogger = (opts : Object = {}) => (reducer : Function) => {
     let log = {};
-    const ua = window && window.navigator.userAgent ? window.navigator.userAgent : '';
+    const ua = typeof window !== 'undefined' && window.navigator.userAgent ? window.navigator.userAgent : '';
     let ms_ie = false;
     //fix for action display in IE
     const old_ie = ua.indexOf('MSIE ');


### PR DESCRIPTION
Allow universal rendering by utilizing a more stringent check for the existence of the window global.
