### PR TITLE
Use default color from browser for the title

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -104,7 +104,7 @@ export const storeLogger = (opts : Object = {}) => (reducer : Function) => {
         stateTransformer : state => state,
         actionTransformer : actn => actn,
         colors : ms_ie ? {} : {
-            title: () => `#000000`,
+            title: null,
             prevState: () => `#9E9E9E`,
             action: () => `#03A9F4`,
             nextState: () => `#4CAF50`,


### PR DESCRIPTION
When using Chrome Dev Tools in dark mode, the title is unreadable (see image)
![image](https://cloud.githubusercontent.com/assets/5701162/19417073/4ae3c538-93a3-11e6-80e2-f506c78a5b8d.png)

By letting the browser take its default color fixes the problem:

![image](https://cloud.githubusercontent.com/assets/5701162/19417202/201ba3c6-93a7-11e6-998c-11167db1f4c4.png)
![image](https://cloud.githubusercontent.com/assets/5701162/19417210/2c153426-93a7-11e6-9f1e-3bd2ba7b4a24.png)

Verified as well on Safari and Firefox
