### PR TITLE
add filtering capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ interface LoggerOptions {
     collapsed? : boolean; //Should log group be collapsed? default: false
     duration? : boolean; //Print duration with action? default: true
     timestamp? : boolean; //Print timestamp with action? default: true
+    filter?: {
+      whitelist?: string[], // Only print actions included in this list - has priority over blacklist
+      blacklist?: string[] // Only print actions that are NOT included in this list
+    }
     stateTransformer? : (state : Object) => Object; //Transform state before print default: state => state
     actionTransformer? : (actn : Object) => Object; //Transform action before print default: actn => actn
     colors? : {

--- a/README.md
+++ b/README.md
@@ -71,3 +71,32 @@ interface LoggerOptions {
     }
 }
 ```
+
+### Filtering
+#### Whitelist
+Only actions included in the list will be printed
+Example:
+``` ts
+const options: LoggerOptions = {
+  filter: {
+    whitelist: ['set-value']
+  }
+}
+storeLogger(options) : Reducer
+```
+With this setup, only action *set-value* will be logged
+
+#### Blacklist
+Action included in the blacklist will not be printed
+Example:
+``` ts
+const options: LoggerOptions = {
+  filter: {
+    blacklist: ['set-value']
+  }
+}
+storeLogger(options) : Reducer
+```
+With this setup, all actions except *set-value* will be printed
+
+*Note*: Whitelist has predence over blacklist. If both are defined, only whitelist will be considered

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,16 @@ const printBuffer = options => logBuffer => {
     logBuffer.length = 0;
 };
 
+const isAllowed = (action, filter) => {
+    if (!filter) {
+        return true;
+    }
+    if (filter.whitelist && filter.whitelist.length) {
+        return filter.whitelist.indexOf(action.type);
+    }
+    return filter.blacklist && filter.blacklist.indexOf(action.type) === -1;
+};
+
 export const storeLogger = (opts : Object = {}) => (reducer : Function) => {
     let log = {};
     const ua = typeof window !== 'undefined' && window.navigator.userAgent ? window.navigator.userAgent : '';
@@ -103,6 +113,10 @@ export const storeLogger = (opts : Object = {}) => (reducer : Function) => {
         timestamp : true,
         stateTransformer : state => state,
         actionTransformer : actn => actn,
+        filter : {
+            whitelist : [],
+            blacklist : []
+        },
         colors : ms_ie ? {} : {
             title: null,
             prevState: () => `#9E9E9E`,
@@ -132,7 +146,7 @@ export const storeLogger = (opts : Object = {}) => (reducer : Function) => {
         };
         log = Object.assign({}, preLog, postLog);
         //ignore init action fired by store and devtools
-        if(action.type !== INIT_ACTION) {
+        if(action.type !== INIT_ACTION && isAllowed(action, options.filter)) {
             buffer([log]);
         }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ const isAllowed = (action, filter) => {
         return true;
     }
     if (filter.whitelist && filter.whitelist.length) {
-        return filter.whitelist.indexOf(action.type);
+        return filter.whitelist.indexOf(action.type) !== -1;
     }
     return filter.blacklist && filter.blacklist.indexOf(action.type) === -1;
 };


### PR DESCRIPTION
Allow users to define filters for logger to only log actions they are interested in.
Filter works in one of two ways:
* whitelist - only actions defined in the whitelist are printed (blacklist is ignored in that case)
* blacklist - action defined in the blacklist are not printed (only works if whitelist is empty/undefined)