### PR TITLE
Fixed warning dependency @ngrx/store@^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/btroncone/ngrx-store-logger#readme",
   "peerDependencies": {
-    "@ngrx/store": "^4.0.0"
+    "@ngrx/store": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
     "@angular/core": "^2.4.7",


### PR DESCRIPTION
Fixed warning dependency @ngrx/store@^5.0.0

warning " > ngrx-store-logger@0.2.0" has incorrect peer dependency "@ngrx/store@^4.0.0".
