### PR TITLE
Changed @ngrx/store peer dependency version to >=4.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/btroncone/ngrx-store-logger#readme",
   "peerDependencies": {
-    "@ngrx/store": "^4.0.0 || ^5.0.0"
+    "@ngrx/store": ">=4.0.0"
   },
   "devDependencies": {
     "@angular/core": "^2.4.7",


### PR DESCRIPTION
Since ngrx-store-logger uses so little of the NgRx API, I think it's best to allow arbitrary future versions.