### PR TITLE
Bump peerDependency of @ngrx/store to include ^8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngrx-store-logger",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Advanced logging middleware for @ngrx/store",
   "main": "./dist/index.js",
   "scripts": {
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/btroncone/ngrx-store-logger#readme",
   "peerDependencies": {
-    "@ngrx/store": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+    "@ngrx/store": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@angular/core": "^2.4.7",


### PR DESCRIPTION
My testing indicates that there are no issues running the logger with angular 8 / @ngrx/store 8. Therefore the peer dependency should be updated in my opinion. I also bumped the version number in package.json.